### PR TITLE
providing a link to the example apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Quickstart
 	
 	`docker run -d --name tyk_redis redis`
 
-4. Run a standalone Tyk Gateway with your (modified) tyk.conf (see sample configs in our docker github repository):
+4. Run a standalone Tyk Gateway with your (modified) tyk.conf (see sample configs in our gateway github https://github.com/TykTechnologies/tyk/tree/master/apps repository):
 
 	`docker run -d --name tyk_gateway -p 8080:8080 --link tyk_redis:redis -v $(pwd)/tyk.standalone.conf:/opt/tyk-gateway/tyk.conf -v $(pwd)/apps:/opt/tyk-gateway/apps tykio/tyk-gateway`
 


### PR DESCRIPTION
change `docker` to `gateway`.
Provide a link to https://github.com/TykTechnologies/tyk/tree/master/apps