### PR TITLE
Replaces editing conf file with env vars

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 
 TYKCONF=/opt/tyk-gateway/tyk.conf
 
-sed -i 's/TYKLISTENPORT/'${TYKLISTENPORT}'/g' ${TYKCONF}
-sed -i 's/TYKSECRET/'${TYKSECRET}'/g' ${TYKCONF}
+export TYK_GW_LISTENPORT="$TYKLISTENPORT"
+export TYK_GW_SECRET="$TYKSECRET"
 
 cd /opt/tyk-gateway/
 ./tyk$TYKLANG --conf=${TYKCONF}

--- a/tyk.standalone.conf
+++ b/tyk.standalone.conf
@@ -1,6 +1,6 @@
 {
-  "listen_port": TYKLISTENPORT,
-  "secret": "TYKSECRET",
+  "listen_port": 8080,
+  "secret": "352d20ee67be67f6340b4c0605b044b7",
   "template_path": "/opt/tyk-gateway/templates",
   "tyk_js_path": "/opt/tyk-gateway/js/tyk.js",
   "middleware_path": "/opt/tyk-gateway/middleware",


### PR DESCRIPTION
Editing a file mounted as a volume can change inode and cause "resource busy" error on docker.