### PR TITLE
Proposal: clean up overriding TYKSECRET in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV TYKVERSION 2.7.5
 ENV TYKLANG ""
 
 ENV TYKLISTENPORT 8080
-ENV TYKSECRET 352d20ee67be67f6340b4c0605b044b7
 
 LABEL Description="Tyk Gateway docker image" Vendor="Tyk" Version=$TYKVERSION
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,15 @@
 
 TYKCONF=/opt/tyk-gateway/tyk.conf
 
-export TYK_GW_LISTENPORT="$TYKLISTENPORT"
-export TYK_GW_SECRET="$TYKSECRET"
+# for backwards compatibility if TYKSECRET is not empty, then set TYK_GW_SECRET to TYKSECRET
+if [[ -n "${TYKSECRET}" ]]; then
+  export TYK_GW_SECRET="${TYKSECRET}"
+fi
+
+# for backwards compatibility if TYK_GW_SECRET is empty, then set to ensure no breaking changes
+if [[ -z "${TYK_GW_SECRET}" ]]; then
+  export TYK_GW_SECRET=352d20ee67be67f6340b4c0605b044b7
+fi
 
 cd /opt/tyk-gateway/
 ./tyk$TYKLANG --conf=${TYKCONF}


### PR DESCRIPTION
Addresses: #16

Allow `TYK_GW_SECRET` to be used to set the secret in gateway.

In order to not introduce breaking changes, legacy `TYKSECRET` takes
precedence.

If `TYK_GW_SECRET` is not set, then we need to hardcode the secret to
ensure no issues if is missing from `tyk.conf`.