### PR TITLE
Fix link to environment-variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ appropriate version for your use-case.
 
 Documentation for gateway configuration can be found here: https://tyk.io/docs/configure/tyk-gateway-configuration-options/
 
-Alternatively, should you wish to configure tyk using environment variables, then you can find the mappings here: https://tyk.io/docs/configure/gateway-env-variables/
+Alternatively, should you wish to configure tyk using environment variables, then you can find the mappings here: https://tyk.io/docs/configure/environment-variables/
 
 Please note that should you wish to change the the gateway secret or listen port as recommended for a production installation, you will need to set `TYKSECRET` and `TYKLISTENPORT` environment variables. The rest of the environment variables remain as per mappings above.
 


### PR DESCRIPTION
https://tyk.io/docs/configure/gateway-env-variables/ gives a 403

Cheers,
David