### PR TITLE
Read Tyk secret from tyk.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
             python3-setuptools \
             libpython3.4 \
- && apt-get install jq \
+            jq \
  && wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && rm get-pip.py \
  && pip3 install grpcio==$GRPCVERSION \
  && apt-get purge -y build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ ENV GRPCVERSION 1.7.0
 ENV TYKVERSION 2.8.3
 ENV TYKLANG ""
 
-ENV TYKLISTENPORT 8080
-
 LABEL Description="Tyk Gateway docker image" Vendor="Tyk" Version=$TYKVERSION
 
 RUN apt-get update \
@@ -21,6 +19,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
             python3-setuptools \
             libpython3.4 \
+ && apt-get install jq \
  && wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && rm get-pip.py \
  && pip3 install grpcio==$GRPCVERSION \
  && apt-get purge -y build-essential \
@@ -40,6 +39,6 @@ VOLUME ["/opt/tyk-gateway/"]
 
 WORKDIR /opt/tyk-gateway/
 
-EXPOSE $TYKLISTENPORT
+EXPOSE 8080
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Documentation for gateway configuration can be found here: https://tyk.io/docs/c
 
 Alternatively, should you wish to configure tyk using environment variables, then you can find the mappings here: https://tyk.io/docs/configure/environment-variables/
 
-Please note that you should set the gateway secret in the `TYKSECRET` environment variable.  If you do not, the entrypoint script will attempt to read the gateway secret into the `TYKSECRET` environment variable from the tyk.conf file.
+Please note that you should set the gateway secret in the `TYK_GW_SECRET` environment variable.  If you do not, the entrypoint script will attempt to set `TYK_GW_SECRET` environment variable from the value of `secret` in tyk.conf.
 
 ```
-TYKSECRET=foo
+TYK_GW_SECRET=foo
 ```
 
 We will now run the gateway by mounting our modified `tyk.conf`.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,10 @@ Documentation for gateway configuration can be found here: https://tyk.io/docs/c
 
 Alternatively, should you wish to configure tyk using environment variables, then you can find the mappings here: https://tyk.io/docs/configure/environment-variables/
 
-Please note that should you wish to change the the gateway secret or listen port as recommended for a production installation, you will need to set `TYKSECRET` and `TYKLISTENPORT` environment variables. The rest of the environment variables remain as per mappings above.
+Please note that you should set the gateway secret in the `TYKSECRET` environment variable.  If you do not, the entrypoint script will attempt to read the gateway secret into the `TYKSECRET` environment variable from the tyk.conf file.
 
 ```
 TYKSECRET=foo
-TYKLISTENPORT=8000
 ```
 
 We will now run the gateway by mounting our modified `tyk.conf`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,23 +2,23 @@
 
 TYKCONF=/opt/tyk-gateway/tyk.conf
 
-# for backwards compatibility if TYKSECRET is empty, then set TYKSECRET to value in tyk.conf
-if [[ -z "${TYKSECRET}" ]]; then
+# for backwards compatibility if TYKSECRET is not empty, then set TYK_GW_SECRET to TYKSECRET
+if [[ -n "${TYKSECRET}" ]]; then
+  export TYK_GW_SECRET="${TYKSECRET}"
+fi
+
+# If no TYK_GW_SECRET env set, we will attempt to set it from the "secret" value in tyk.conf
+if [[ -z "${TYK_GW_SECRET}" ]]; then
   echo "**************************************************************************************************************"
   echo "*                                           WARNING                                                          *"
   echo "**               USING GATEWAY SECRET IN TYK.CONF BECAUSE NO ENV VARIABLE SET                               **"
   echo "*                                REFER TO IMAGE README FOR MORE INFO                                         *"
   echo "**************************************************************************************************************"
   echo ""
-  export TYKSECRET=$(cat tyk.conf | jq -r .secret)
-fi  
-
-# for backwards compatibility if TYKSECRET is not empty, then set TYK_GW_SECRET to TYKSECRET
-if [[ -n "${TYKSECRET}" ]]; then
-  export TYK_GW_SECRET="${TYKSECRET}"
+  export TYK_GW_SECRET=$(cat $TYKCONF | jq -r .secret)
 fi
 
-# for backwards compatibility if TYK_GW_SECRET is empty, then set to ensure no breaking changes
+# If no secret found in tyk.conf, will use default license
 if [[ -z "${TYK_GW_SECRET}" ]]; then
   export TYK_GW_SECRET=352d20ee67be67f6340b4c0605b044b7
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,17 @@
 
 TYKCONF=/opt/tyk-gateway/tyk.conf
 
+# for backwards compatibility if TYKSECRET is empty, then set TYKSECRET to value in tyk.conf
+if [[ -z "${TYKSECRET}" ]]; then
+  echo "**************************************************************************************************************"
+  echo "*                                           WARNING                                                          *"
+  echo "**               USING GATEWAY SECRET IN TYK.CONF BECAUSE NO ENV VARIABLE SET                               **"
+  echo "*                                REFER TO IMAGE README FOR MORE INFO                                         *"
+  echo "**************************************************************************************************************"
+  echo ""
+  export TYKSECRET=$(cat tyk.conf | jq -r .secret)
+fi  
+
 # for backwards compatibility if TYKSECRET is not empty, then set TYK_GW_SECRET to TYKSECRET
 if [[ -n "${TYKSECRET}" ]]; then
   export TYK_GW_SECRET="${TYKSECRET}"


### PR DESCRIPTION
### Problem
Currently, many users have been running into circles trying to understand why their Gateway secret is not working. It's because the entrypoint script is overriding the tyk.conf secret with an environment variable.  If the environment variable doesn't exist, the entrypoint script uses the default license.

This flow is causing users problems because it is not intuitive.

### First change
If the entrypoint script doesn't detect an environment variable, it will read the one from the tyk.conf and put it into the environment variable, instead of automatically assigning the default dev license.  This ensures backwards compatibility for users who are using env variables and not the tyk.conf secret

3 cases i can think of to use this docker image:
1)  using an env variable for the secret - will continue to work as normal.  the entrypoint script will see that there is an env variable set and will not overwrite it
2) no env variable, secret not set in tyk.conf - the entrypoint script will set the env variable to the default license, which is the same behaviour as before these changes.

**the third case is the one that is causing users problems and the point of this pull request:**
3) no env variable, secret is set in tyk.conf - the entrypoint script will set the env variable to the secret in the tyk.conf

### Second change
I also got rid of the env variable TYKLISTENPORT because this image was merely exposing the port.  Which actually does nothing unless the user runs the docker container with the "-p" flag and explicitly opens up that port as well.  It is mostly there to tell users that they have to remember to expose the port when running the container.