### PR TITLE
Fixes Python dispatcher failing to initialise (#35)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,12 @@ RUN apt-get update \
             build-essential \
             python3-setuptools \
             libpython3.7 \
+            python3.7-dev \
             jq \
+ && rm -rf /usr/include/* && rm /usr/lib/x86_64-linux-gnu/*.a && rm /usr/lib/x86_64-linux-gnu/*.o \
+ && rm /usr/lib/python3.7/config-3.7m-x86_64-linux-gnu/*.a \
  && wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && rm get-pip.py \
- && pip3 install grpcio==$GRPCVERSION \
+ && pip3 install protobuf grpcio==$GRPCVERSION \
  && apt-get purge -y build-essential \
  && apt-get autoremove -y \
  && rm -rf /root/.cache


### PR DESCRIPTION
Since v2.9.0 Python dispatcher is automatically searching for libpython and links to it dynamically. In order for auto-detection to work it fist searches for "python3<something>-config" executable, which knows locations of libraries and other files usually called for development purposes. For this reason it's not a part of "libpython<something>" packages, but rather "libpython<something>-dev" packages. So this package needs to be installed too, which indeed solves the issue, however it also brings 110MB of overhead along with its dependencies.

In order to combat this, we manually delete all the space consuming files that are not really needed to execute this container in a meaningful way. This keeps the overhead to 1MB. Better solution requires changes in Tyk gateway, so that's hopefully temporary.

Another issue found is the "grpcio" Python package doesn't depend on the "protobuf" package anymore, but it's required by the gateway's Python bindings — plugins won't work without it. So this installs the "protobuf" package explicitly now, which adds 1MB more (compared to original "v2.9.2" image).