### PR TITLE
Modifying docker image to run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,6 @@ WORKDIR /opt/tyk-gateway/
 
 EXPOSE 8080
 
+USER 999:999
+
 ENTRYPOINT ["./entrypoint.sh"]

--- a/tyk.standalone.conf
+++ b/tyk.standalone.conf
@@ -1,5 +1,6 @@
 {
   "listen_port": 8080,
+  "pid_file_location": "/tmp/tyk-gateway.pid",
   "secret": "352d20ee67be67f6340b4c0605b044b7",
   "template_path": "/opt/tyk-gateway/templates",
   "tyk_js_path": "/opt/tyk-gateway/js/tyk.js",

--- a/tyk.with_dashboard.conf
+++ b/tyk.with_dashboard.conf
@@ -1,5 +1,6 @@
 {
   "listen_port": 8080,
+  "pid_file_location": "/tmp/tyk-gateway.pid",
   "secret": "352d20ee67be67f6340b4c0605b044b7",
   "node_secret": "352d20ee67be67f6340b4c0605b044b7",
   "template_path": "/opt/tyk-gateway/templates",


### PR DESCRIPTION
Hi everyone, 
consider please following changes.

I'm deploying TYK as api gateway in Kubernetes cluster with Pod Security Policies enabled and running containers as non root.

TyK installation during container creation creates the tyk user in the system with uid and gid `999` but resulting container image run gateway as root. 

This merge request contain changes which I use in my deployment.

There is only one thing when running tyk as non-root and it's pid file path, so I changed path to pidfile in tyk configuration.

I'm using numeric notation in `USER` definition becouse of Kubernetes and Pod Security Policies.

## Important
Be aware because changing this will also need change in number of other places where you have tyk.conf defined (helm charts, deployments, etc)