### PR TITLE
Synced the value of TYK_GW_SECRET with tyk.standlone.conf

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./middleware:/opt/tyk-gateway/middleware
       - ./certs:/opt/tyk-gateway/certs
     environment:
-      - TYK_GW_SECRET=foo
+      - TYK_GW_SECRET=352d20ee67be67f6340b4c0605b044b7
     depends_on:
       - tyk-redis
   tyk-redis:


### PR DESCRIPTION
The value of TYK_GW_SECRET is now synched with the value in tyk.standalone.conf.

Reason : Anyone new to Tyk, following our docs on OSS, doesn't know about this and is facing an issue while trying to publish changes.
https://tyk.io/docs/getting-started/create-api/

Here is a thread related to this.

https://stackoverflow.com/questions/68155402/tyk-io-attempted-administrative-access-with-invalid-or-missing-key