### PR TITLE
TT-3361 - disable enable_health_checks by default in master

### DIFF
--- a/tyk.hybrid.conf
+++ b/tyk.hybrid.conf
@@ -27,7 +27,7 @@
         "ignored_ips": []
     },
     "health_check": {
-        "enable_health_checks": true,
+        "enable_health_checks": false,
         "health_check_value_timeouts": 60
     },
     "optimisations_use_async_session_write": false,

--- a/tyk.standalone.conf
+++ b/tyk.standalone.conf
@@ -27,7 +27,7 @@
     "ignored_ips": []
   },
   "health_check": {
-    "enable_health_checks": true,
+    "enable_health_checks": false,
     "health_check_value_timeouts": 60
   },
   "optimisations_use_async_session_write": false,

--- a/tyk.standalone.tls.conf
+++ b/tyk.standalone.tls.conf
@@ -27,7 +27,7 @@
     "ignored_ips": []
   },
   "health_check": {
-    "enable_health_checks": true,
+    "enable_health_checks": false,
     "health_check_value_timeouts": 60
   },
   "optimisations_use_async_session_write": false,

--- a/tyk.with_dashboard.conf
+++ b/tyk.with_dashboard.conf
@@ -35,7 +35,7 @@
     "ignored_ips": []
   },
   "health_check": {
-    "enable_health_checks": true,
+    "enable_health_checks": false,
     "health_check_value_timeouts": 60
   },
   "optimisations_use_async_session_write": false,


### PR DESCRIPTION
The enable_health_checks feature is deprecated due to performance issues.  This PR disables it by default in the various config files.