### PR TITLE
fix policy path to use a folder instead of file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./apps:/opt/tyk-gateway/apps
       - ./middleware:/opt/tyk-gateway/middleware
       - ./certs:/opt/tyk-gateway/certs
+      - ./policies:/opt/tyk-gateway/policies
     environment:
       - TYK_GW_SECRET=foo
     depends_on:

--- a/tyk.standalone.conf
+++ b/tyk.standalone.conf
@@ -32,7 +32,7 @@
   "allow_master_keys": false,
   "policies": {
     "policy_source": "file",
-    "policy_record_name": "/opt/tyk-gateway/policies/policies.json"
+    "policy_path": "/opt/tyk-gateway/policies"
   },
   "hash_keys": true,
   "close_connections": false,


### PR DESCRIPTION
[policy_path](https://tyk.io/docs/tyk-oss-gateway/configuration/#policiespolicy_path): This points to a directory/folder and was introduced in version [4.1](https://tyk.io/docs/release-notes/version-4.1/#tyk-gateway) when managing policies through REST APIs was added. This is now the recommended way of managing your policies.