### PR TITLE
"driver": "otto" updated at correct place in apps/keyless-plugin-api.…

### DIFF
--- a/apps/keyless-plugin-api.json
+++ b/apps/keyless-plugin-api.json
@@ -17,18 +17,18 @@
     },
     "custom_middleware": {
         "pre": [
-          {
-            "name": "testJSVMData",
-            "path": "./middleware/injectHeader.js",
-            "require_session": false,
-            "raw_body_only": false
-          }
-        ]
-  },
-    "driver": "otto",
+            {
+                "name": "testJSVMData",
+                "path": "middleware/injectHeader.js",
+                "require_session": false,
+                "raw_body_only": false
+            }
+        ],
+        "driver": "otto"
+    },
     "proxy": {
         "listen_path": "/keyless-test/",
-        "target_url": "http://httpbin.org",
+        "target_url": "https://karan.requestcatcher.com",
         "strip_listen_path": true
     }
 }


### PR DESCRIPTION
the js middleware fiven in the example doesnt work and i got an error while booting up the gateway
`level=error msg="Unsupported driver ''" prefix=coprocess`

https://github.com/TykTechnologies/tyk/issues/4422
This issue mentions that driver needed to be inside custom_middleware