### PR TITLE
Fix `"driver": "otto"` location in keyless-plugin-api.json

### DIFF
--- a/apps/keyless-plugin-api.json
+++ b/apps/keyless-plugin-api.json
@@ -16,6 +16,7 @@
         }
     },
     "custom_middleware": {
+        "driver": "otto",
         "pre": [
           {
             "name": "testJSVMData",
@@ -25,7 +26,6 @@
           }
         ]
   },
-    "driver": "otto",
     "proxy": {
         "listen_path": "/keyless-test/",
         "target_url": "http://httpbin.org",


### PR DESCRIPTION
Moving the `"driver": "otto"` line of keyless-plugin-api.json to its correct position within the `"custom_middleware": {...}` block. At present, it is outside this block and thus the plugin fails to execute. By moving it within custom_middleware, the plugin will execute successfully.