### PR TITLE
Update deprecated docker-compose.yml docker image host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   tyk-gateway:
-    image: docker.tyk.io/tyk-gateway/tyk-gateway:v5.5.0
+    image: tykio/tyk-gateway:v5.5.0
     ports:
       - 8080:8080
     networks:


### PR DESCRIPTION
This pull request includes a small but important change to the `docker-compose.yml` file. The change updates the image source for the `tyk-gateway` service.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L4-R4): Changed the image source for the `tyk-gateway` service from `docker.tyk.io/tyk-gateway/tyk-gateway:v5.5.0` to `tykio/tyk-gateway:v5.5.0`.