### PR TITLE
Update Redis to 6.2.20-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - tyk-redis
   tyk-redis:
-    image: redis:6.2.7-alpine
+    image: redis:6.2.20-alpine
     networks:
       - tyk
     ports:


### PR DESCRIPTION
This patches redis against CVE-2025-49844